### PR TITLE
youtube api gets artist name of the video owner not of the playlist owner

### DIFF
--- a/ChordKTV/Program.cs
+++ b/ChordKTV/Program.cs
@@ -53,7 +53,7 @@ app.UseSwagger();
 app.UseSwaggerUI();
 //}
 
-// app.UseHttpsRedirection();
+app.UseHttpsRedirection();
 
 app.UseAuthorization();
 

--- a/ChordKTV/Program.cs
+++ b/ChordKTV/Program.cs
@@ -53,7 +53,7 @@ app.UseSwagger();
 app.UseSwaggerUI();
 //}
 
-app.UseHttpsRedirection();
+// app.UseHttpsRedirection();
 
 app.UseAuthorization();
 

--- a/ChordKTV/Services/Service/YouTubeClientService.cs
+++ b/ChordKTV/Services/Service/YouTubeClientService.cs
@@ -66,7 +66,7 @@ public class YouTubeApiClientService : IYouTubeClientService
                 {
                     string title = item.Snippet.Title;
                     string url = $"https://www.youtube.com/watch?v={videoId}";
-                    
+
                     videos.Add(new VideoInfo(
                         title,
                         details.ChannelTitle,  // Use the correct channel name
@@ -83,12 +83,12 @@ public class YouTubeApiClientService : IYouTubeClientService
         return new PlaylistDetailsDto(playlistTitle, videos);
     }
 
-    private record VideoDetails(string ChannelTitle, TimeSpan Duration);
+    private sealed record VideoDetails(string ChannelTitle, TimeSpan Duration);
 
-    private async Task<Dictionary<string, VideoDetails>> GetVideosDetailsAsync(YouTubeService youTubeService, List<string> videoIds)
+    private static async Task<Dictionary<string, VideoDetails>> GetVideosDetailsAsync(YouTubeService youTubeService, List<string> videoIds)
     {
         var result = new Dictionary<string, VideoDetails>();
-        
+
         // YouTube API allows up to 50 video IDs per request
         foreach (var idBatch in videoIds.Chunk(50))
         {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
Fixes the problem in Youtube API where getting the video data form a playlist ID returned back the playlist owner name for each video, instead of that video's actual posting name (the artist).

## 🔍 Related Issues
Fixes #12 

## 📷 Screenshots (if applicable)
Each "channel" returned back now represents the name of the channel that uploaded the video in the playlist, not the playlist owner.
<img width="1074" alt="Screen Shot 2025-02-09 at 7 00 29 PM" src="https://github.com/user-attachments/assets/ba1229b7-7ea8-49e3-849f-dcdf295c1f9b" />


## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
