### PR TITLE
Backend lrc search tuning

### DIFF
--- a/ChordKTV/Controllers/SongController.cs
+++ b/ChordKTV/Controllers/SongController.cs
@@ -85,7 +85,7 @@ public class SongController : Controller
     }
 
     [HttpGet("lyrics/lrclib/fuzzy_search")]
-    public async Task<IActionResult> GetLrcLibLyrics([FromQuery] string title, [FromQuery] string qString)
+    public async Task<IActionResult> GetLrcLibLyrics([FromQuery] string? title, [FromQuery] string? qString)
     {
         try
         {

--- a/ChordKTV/Controllers/SongController.cs
+++ b/ChordKTV/Controllers/SongController.cs
@@ -78,14 +78,14 @@ public class SongController : Controller
                 return BadRequest(new { message = "Both title and artist are required for searchType=exact" });
             }
 
-            if (searchType == "fuzzy" && string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(qString))
+            if (searchType == "fuzzy" && string.IsNullOrWhiteSpace(qString))
             {
-                return BadRequest(new { message = "At least one of 'title' or 'qString' must be provided for searchType=fuzzy" });
+                return BadRequest(new { message = "'qString' is required for searchType=fuzzy" });
             }
 
             LrcLyricsDto? lyrics = searchType == "exact"
                 ? await _lrcService.GetLrcLibLyricsAsync(title, artist, albumName, null, duration)
-                : await _lrcService.GetLrcLibLyricsAsync(title, null, null, qString, null);
+                : await _lrcService.GetLrcLibLyricsAsync(null, null, null, qString, null);
 
             if (lyrics == null)
             {

--- a/ChordKTV/Dtos/LrcLyricsDto.cs
+++ b/ChordKTV/Dtos/LrcLyricsDto.cs
@@ -2,7 +2,8 @@ namespace ChordKTV.Dtos;
 
 public class LrcLyricsDto
 {
-    public int Id { get; set; }
+    public int Id { get; set; } // ID of original language song in LRCLIB
+    public int? RomanizedId { get; set; } // ID of romanized song in LRCLIB
     public string? Name { get; set; } // LRCLIB returns both a name and a track name, storing both
     public string? TrackName { get; set; }
     public string? ArtistName { get; set; }

--- a/ChordKTV/Program.cs
+++ b/ChordKTV/Program.cs
@@ -67,7 +67,7 @@ app.UseSwaggerUI();
 //}
 
 // Comment out HTTPS redirection for development
-// app.UseHttpsRedirection();
+app.UseHttpsRedirection();
 
 app.UseAuthorization();
 

--- a/ChordKTV/Program.cs
+++ b/ChordKTV/Program.cs
@@ -67,7 +67,7 @@ app.UseSwaggerUI();
 //}
 
 // Comment out HTTPS redirection for development
-app.UseHttpsRedirection();
+// app.UseHttpsRedirection();
 
 app.UseAuthorization();
 

--- a/ChordKTV/README.md
+++ b/ChordKTV/README.md
@@ -62,7 +62,23 @@ dotnet ef migrations add <migration name>
 dotnet ef database update
 ```
 
+## API Documentation
 
+#### ```GET /api/lyrics/lrclib/search```
+
+Returns time-synced lyrics from LRCLIB. Attempts to retrieve both original and romanized lyrics if they exist.
+Allows to perform either an exact search or a fuzzy search with the searchType query parameter (must be either "exact" or "fuzzy")
+If searchType is "fuzzy", the API only looks at the qString parameter (due to LRCLIB API doing the same thing)
+If searchType is "exact" the API looks at all fields except for qString.
+
+Swagger spec:
+![image](https://github.com/user-attachments/assets/758b8ed1-d081-4afd-a0e3-fd3e203197dd)
+
+Note: need to be careful with the "fuzzy" search mode. Example bug case:
+![image](https://github.com/user-attachments/assets/1a1aa934-4af8-44e0-9c27-4bd499a3f28a)
+![image](https://github.com/user-attachments/assets/1401fab4-bd66-46df-9074-4b9e68409ffc)
+
+The API returned the romanized lyrics for the Spanish version of the song. Since it only looks for the first entry in LRCLIB with time-synced lyrics, it has no way of validating whether those lyrics are actually the romanized version of the original song.
 
 ## License 📜📝⚖️
 This project is licensed under the [**MIT License**](LICENSE). 🎼🎵🎧

--- a/ChordKTV/Services/Api/ILrcService.cs
+++ b/ChordKTV/Services/Api/ILrcService.cs
@@ -4,7 +4,6 @@ namespace ChordKTV.Services.Api;
 
 public interface ILrcService
 {
-    public Task<LrcLyricsDto?> GetLrcLibLyricsAsync(string title, string artist, string? albumName, float? duration);
-
-    public Task<LrcLyricsDto?> GetLrcRomanizedLyricsAsync(LrcLyricsDto lyricsDto);
+    // Added "qString" which LRCLIB uses to search for keyword present in ANY fields (track's title, artist name or album name)
+    public Task<LrcLyricsDto?> GetLrcLibLyricsAsync(string? title, string? artist, string? albumName, string? qString, float? duration);
 }

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -44,7 +44,6 @@ public class FullSongService : IFullSongService
         {
             song.Duration ??= duration;
             float? songDuration = (float?)song.Duration?.TotalSeconds;
-            // lyricsDto = await _lrcService.GetLrcLibLyricsAsync(song.Title, song.Artist, song.Albums.FirstOrDefault()?.Name, songDuration);
 
             //TODO: Delete once issue #48 solved
             lyricsDto = await _lrcService.GetLrcLibLyricsAsync(song.Title, song.Artist, null, null, null);
@@ -61,7 +60,6 @@ public class FullSongService : IFullSongService
             song.LrcLyrics = lyricsDto.SyncedLyrics;
 
             //TODO: Refactor once issue #52 solved
-            // lyricsDto = await _lrcService.GetLrcRomanizedLyricsAsync(lyricsDto);
             //TODO: ASSIGN LRC LYRIC ID TO SONG (not assigned in lrc service as of 2/11/25)
         }
 

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -47,7 +47,7 @@ public class FullSongService : IFullSongService
             // lyricsDto = await _lrcService.GetLrcLibLyricsAsync(song.Title, song.Artist, song.Albums.FirstOrDefault()?.Name, songDuration);
 
             //TODO: Delete once issue #48 solved
-            lyricsDto = await _lrcService.GetLrcLibLyricsAsync(song.Title, song.Artist, null, null);
+            lyricsDto = await _lrcService.GetLrcLibLyricsAsync(song.Title, song.Artist, null, null, null);
 
             if (lyricsDto is null || string.IsNullOrWhiteSpace(lyricsDto.SyncedLyrics))
             {
@@ -61,7 +61,7 @@ public class FullSongService : IFullSongService
             song.LrcLyrics = lyricsDto.SyncedLyrics;
 
             //TODO: Refactor once issue #52 solved
-            lyricsDto = await _lrcService.GetLrcRomanizedLyricsAsync(lyricsDto);
+            // lyricsDto = await _lrcService.GetLrcRomanizedLyricsAsync(lyricsDto);
             //TODO: ASSIGN LRC LYRIC ID TO SONG (not assigned in lrc service as of 2/11/25)
         }
 

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -63,7 +63,7 @@ public class LrcService : ILrcService
         {
             query += $"&q={Uri.EscapeDataString(qString)}";
         }
-        
+
         HttpResponseMessage response = await _httpClient.GetAsync($"https://lrclib.net/api/search?{query}");
         if (response.IsSuccessStatusCode)
         {
@@ -77,8 +77,14 @@ public class LrcService : ILrcService
                 {
                     string plainLyrics = ele.GetProperty("plainLyrics").GetString() ?? "";
                     string syncedLyrics = ele.GetProperty("syncedLyrics").GetString() ?? "";
-                    float durationMatch = ele.GetProperty("duration").GetSingle();
-                    return plainLyrics != null && syncedLyrics != null && durationMatch == duration;
+                    float duration_ = ele.GetProperty("duration").GetSingle();
+                    bool durationMatch = true;
+                    // If the duration field was given, check if entry has same duration (defaults to true if no duration given)
+                    if (duration.HasValue && duration_ != duration)
+                    {
+                        durationMatch = false;
+                    }
+                    return plainLyrics != null && syncedLyrics != null && durationMatch;
                 });
 
                 if (lyricsDtoMatch == null)
@@ -101,16 +107,22 @@ public class LrcService : ILrcService
                         {
                             string plainLyrics = ele.GetProperty("plainLyrics").GetString() ?? "";
                             string syncedLyrics = ele.GetProperty("syncedLyrics").GetString() ?? "";
-                            float durationMatch = ele.GetProperty("duration").GetSingle();
-                            return plainLyrics != null && IsRomanized(plainLyrics) && syncedLyrics != null && durationMatch == duration;
+                            float duration_ = ele.GetProperty("duration").GetSingle();
+                            bool durationMatch = true;
+                            // If the duration field was given, check if entry has same duration (defaults to true if no duration given)
+                            if (duration.HasValue && duration_ != duration)
+                            {
+                                durationMatch = false;
+                            }
+                            return plainLyrics != null && IsRomanized(plainLyrics) && syncedLyrics != null && durationMatch;
                         });
 
                     if (romanizedMatch != null && romanizedMatch.Value.ValueKind != JsonValueKind.Undefined)
                     {
                         lyricsDto.RomanizedPlainLyrics = romanizedMatch.Value.GetProperty("plainLyrics").GetString();
                         lyricsDto.RomanizedSyncedLyrics = romanizedMatch.Value.GetProperty("syncedLyrics").GetString();
-                        return lyricsDto;
                     }
+                    return lyricsDto;
                 }
                 else // If already romanized, look for original lang
                 {
@@ -123,8 +135,14 @@ public class LrcService : ILrcService
                         {
                             string plainLyrics = ele.GetProperty("plainLyrics").GetString() ?? "";
                             string syncedLyrics = ele.GetProperty("syncedLyrics").GetString() ?? "";
-                            float durationMatch = ele.GetProperty("duration").GetSingle();
-                            return plainLyrics != null && !IsRomanized(plainLyrics) && syncedLyrics != null && durationMatch == duration;
+                            float duration_ = ele.GetProperty("duration").GetSingle();
+                            bool durationMatch = true;
+                            // If the duration field was given, check if entry has same duration (defaults to true if no duration given)
+                            if (duration.HasValue && duration_ != duration)
+                            {
+                                durationMatch = false;
+                            }
+                            return plainLyrics != null && !IsRomanized(plainLyrics) && syncedLyrics != null && durationMatch;
                         });
 
 

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -91,7 +91,6 @@ public class LrcService : ILrcService
                 {
                     return null;
                 }
-                
                 LrcLyricsDto? lyricsDto = JsonSerializer.Deserialize<LrcLyricsDto>(lyricsDtoMatch.Value.ToString(), _jsonSerializerOptions);
 
                 if (lyricsDto == null) // Shouldn't happen if lyricsDtoMatch wasn't null, throwing this check in for linter

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -121,6 +121,7 @@ public class LrcService : ILrcService
                     {
                         lyricsDto.RomanizedPlainLyrics = romanizedMatch.Value.GetProperty("plainLyrics").GetString();
                         lyricsDto.RomanizedSyncedLyrics = romanizedMatch.Value.GetProperty("syncedLyrics").GetString();
+                        lyricsDto.RomanizedId = romanizedMatch.Value.GetProperty("id").GetInt32();
                     }
                     return lyricsDto;
                 }
@@ -128,6 +129,7 @@ public class LrcService : ILrcService
                 {
                     string? romanizedPlainLyrics = lyricsDto.PlainLyrics;
                     string? romanizedSyncedLyrics = lyricsDto.SyncedLyrics;
+                    int? romanizedId = lyricsDto.Id;
 
                     // Look for any other result that has original lyrics
                     JsonElement? origMatch = searchResults
@@ -150,14 +152,12 @@ public class LrcService : ILrcService
                     {
                         lyricsDto.PlainLyrics = origMatch.Value.GetProperty("plainLyrics").GetString();
                         lyricsDto.SyncedLyrics = origMatch.Value.GetProperty("syncedLyrics").GetString();
-                        lyricsDto.RomanizedPlainLyrics = romanizedPlainLyrics;
-                        lyricsDto.RomanizedSyncedLyrics = romanizedSyncedLyrics;
+                        lyricsDto.Id = origMatch.Value.GetProperty("id").GetInt32();
                     }
-                    else // In this case, song was originally English
-                    {
-                        lyricsDto.RomanizedPlainLyrics = romanizedPlainLyrics;
-                        lyricsDto.RomanizedSyncedLyrics = romanizedSyncedLyrics;
-                    }
+
+                    lyricsDto.RomanizedPlainLyrics = romanizedPlainLyrics;
+                    lyricsDto.RomanizedSyncedLyrics = romanizedSyncedLyrics;
+                    lyricsDto.RomanizedId = romanizedId;
 
                     return lyricsDto;
                 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Added /api/lyrics/lrclib/exact_search and /api/lyrics/lrclib/fuzzy_search endpoints. Also adds RomanizedId field to DTO to store ID of romanized LRCLIB entry.
Changed the LRC search service function to only use the api/search LRCLIB API endpoint, still uses duration field even though LRCLIB API does not accept that (by checking duration value in filtering)

## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #44, #48

## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->
Exact search endpoint:
![image](https://github.com/user-attachments/assets/6a9c705b-8ab3-48a3-9571-2b3a156c26b9)

Fuzzy search endpoint:
![image](https://github.com/user-attachments/assets/e359d922-9755-4735-a06b-3ddb15c17f55)

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->