### PR TITLE
Replace youtube url with youtube id for API req

### DIFF
--- a/frontend/lyric-sync-app/src/components/YouTubePlaylistViewer/YouTubePlaylistViewer.tsx
+++ b/frontend/lyric-sync-app/src/components/YouTubePlaylistViewer/YouTubePlaylistViewer.tsx
@@ -68,7 +68,7 @@ const YouTubePlaylistViewer: React.FC<YouTubePlaylistViewerProps> = ({ playlistU
   };
 
   const extractYouTubeVideoId = (url: string | null | undefined): string | null => {
-    if (!url) return null;
+    if (!url) {return null;}
     const match = url.match(/(?:\?v=|\/embed\/|\.be\/|\/watch\?v=|\/watch\?.+&v=)([a-zA-Z0-9_-]{11})/);
     return match ? match[1] : null;
   };

--- a/frontend/lyric-sync-app/src/components/YouTubePlaylistViewer/YouTubePlaylistViewer.tsx
+++ b/frontend/lyric-sync-app/src/components/YouTubePlaylistViewer/YouTubePlaylistViewer.tsx
@@ -67,14 +67,21 @@ const YouTubePlaylistViewer: React.FC<YouTubePlaylistViewerProps> = ({ playlistU
     }
   };
 
+  const extractYouTubeVideoId = (url: string | null | undefined): string | null => {
+    if (!url) return null;
+    const match = url.match(/(?:\?v=|\/embed\/|\.be\/|\/watch\?v=|\/watch\?.+&v=)([a-zA-Z0-9_-]{11})/);
+    return match ? match[1] : null;
+  };
+
   const handleRowClick = async (params: GridRowParams) => {
     setSearchLoading(true);
     try {
+      const vidId = extractYouTubeVideoId(params.row.url);
       const response = await songApi.apiSongsSearchPost({
         fullSongRequestDto: {
           title: params.row.title,
           artist: params.row.artist,
-          youTubeId: params.row.url
+          youTubeId: vidId
         }
       });
       setSong(response);


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
After the backend switched from YouTube URL to YouTube ID for full song endpoint request, the frontend was not updated for the playlist input.

## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->


## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
