### PR TITLE
Embedded player failing youtube bug fix

### DIFF
--- a/ChordKTV/Services/Service/YouTubeClientService.cs
+++ b/ChordKTV/Services/Service/YouTubeClientService.cs
@@ -171,6 +171,7 @@ public class YouTubeApiClientService : IYouTubeClientService, IDisposable
         searchRequest.Q = $"{title} {artist} {album ?? ""}";
         searchRequest.Type = "video";
         searchRequest.MaxResults = 4; //more simple, maybe expand in future to allow users to choose, 2 groups based on relevancy sort
+        searchRequest.VideoEmbeddable = SearchResource.ListRequest.VideoEmbeddableEnum.True__;
 
         //https://stackoverflow.com/a/17738994/17621099 category type 10 is music for all regions where allowed
         searchRequest.VideoCategoryId = "10";

--- a/ChordKTV/Services/Service/YouTubeClientService.cs
+++ b/ChordKTV/Services/Service/YouTubeClientService.cs
@@ -174,7 +174,7 @@ public class YouTubeApiClientService : IYouTubeClientService, IDisposable
         searchRequest.VideoEmbeddable = SearchResource.ListRequest.VideoEmbeddableEnum.True__;
 
         //https://stackoverflow.com/a/17738994/17621099 category type 10 is music for all regions where allowed
-        searchRequest.VideoCategoryId = "10";
+        // searchRequest.VideoCategoryId = "10"; //disabled for now, might be too specific
 
         SearchListResponse searchResponse = await searchRequest.ExecuteAsync();
         //first search response item that has video id


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Allow embeddable playable videos only when searching, previous licensed songs will no longer error out. 

## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #115 
Potentially will cause issues with embedded when playlist has video that's unavail, because we don't do filter search on playlist (youtube doesn't have that in the playlist params I think). Will make issue when encountered.

## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->
Previously not working. Now works
![image](https://github.com/user-attachments/assets/2dcbc4b7-881a-47a3-b43d-e7a7a1a49fb8)

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
