### PR TITLE
Backend gpt prompt revision fix

### DIFF
--- a/ChordKTV/Dtos/OpenAI/TranslatedSongLyrics.cs
+++ b/ChordKTV/Dtos/OpenAI/TranslatedSongLyrics.cs
@@ -1,0 +1,7 @@
+namespace ChordKTV.Dtos.OpenAI;
+public record TranslatedSongLyrics
+(
+    string? RomanizedLyrics,
+    string? TranslatedLyrics,
+    string LanguageCode
+);

--- a/ChordKTV/Services/Service/ChatGptService.cs
+++ b/ChordKTV/Services/Service/ChatGptService.cs
@@ -115,7 +115,7 @@ You are a helpful assistant that translates LRC formatted lyrics into an English
         {
             if (parsedLanguageCode == LanguageCode.UNK)
             {
-                _logger.LogError("Unkown language code returned from ChatGPT API: {LanguageCode} \n Lyrics: {OriginalLyrics}", translatedSongLyrics.LanguageCode, originalLyrics);
+                _logger.LogError("Unknown language code returned from ChatGPT API: {LanguageCode} \n Lyrics: {OriginalLyrics}", translatedSongLyrics.LanguageCode, originalLyrics);
             }
             else
             {

--- a/ChordKTV/Services/Service/ChatGptService.cs
+++ b/ChordKTV/Services/Service/ChatGptService.cs
@@ -48,8 +48,8 @@ public class ChatGptService : IChatGptService
             throw new ArgumentException($"Error in {nameof(TranslateLyricsAsync)}: At least one of romanize or translate must be true.");
         }
         string prompt = $@"
-        You are a helpful assistant that translates LRC formatted lyrics into an English translation (if needed) and, if needed, a romanized version (using the English alphabet) while maintaining the same format.
-        Is romanization needed: {(romanize ? "Yes" : "No")}
+You are a helpful assistant that translates LRC formatted lyrics into an English translation (if needed) and, if needed, a romanized version (using the English alphabet) while maintaining the same format.
+Is romanization needed: {(romanize ? "Yes" : "No")}
 Is translation needed: {(translate ? "Yes" : "No")}
 Notice the only exception to this is if the original lyrics are already in English, in which case no translation or romanization is needed. This occurs if language code is UNK, correct to EN if it is english and null out romanization and translation.
 If not needed, have the json response for the section be null or not there. Maintain the LRC text format timestamps exactly in the responses.

--- a/ChordKTV/Services/Service/ChatGptService.cs
+++ b/ChordKTV/Services/Service/ChatGptService.cs
@@ -118,24 +118,21 @@ You are a helpful assistant that translates LRC formatted lyrics into an English
         {
             _logger.LogError("Failed to parse language code from ChatGPT API response: {LanguageCode} \n Lyrics: {OriginalLyrics}", translatedSongLyrics.LanguageCode, originalLyrics);
         }
-        if (languageCode == LanguageCode.EN)
+        if (languageCode != LanguageCode.EN)
         {
-            romanize = false;
-            translate = false;
-        }
-
-        if ((romanize && string.IsNullOrEmpty(translatedSongLyrics.RomanizedLyrics)) || (translate && string.IsNullOrEmpty(translatedSongLyrics.TranslatedLyrics)))
-        {
-            _logger.LogError("messageContent: {MessageContent}", messageContent);
-            throw new InvalidOperationException($"Error in {nameof(TranslateLyricsAsync)}: The ChatGPT API response did not contain the expected translations.");
+            if ((romanize && string.IsNullOrEmpty(translatedSongLyrics.RomanizedLyrics)) || (translate && string.IsNullOrEmpty(translatedSongLyrics.TranslatedLyrics)))
+            {
+                _logger.LogError("messageContent: {MessageContent}", messageContent);
+                throw new InvalidOperationException($"Error in {nameof(TranslateLyricsAsync)}: The ChatGPT API response did not contain the expected translations.");
+            }
         }
 
         return new TranslationResponseDto
         {
             OriginalLyrics = originalLyrics,
             LanguageCode = languageCode,
-            RomanizedLyrics = translatedSongLyrics.RomanizedLyrics,
-            TranslatedLyrics = translatedSongLyrics.TranslatedLyrics,
+            RomanizedLyrics = languageCode == LanguageCode.EN ? originalLyrics : translatedSongLyrics.RomanizedLyrics,
+            TranslatedLyrics = languageCode == LanguageCode.EN ? originalLyrics : translatedSongLyrics.TranslatedLyrics,
         };
     }
 

--- a/ChordKTV/Services/Service/ChatGptService.cs
+++ b/ChordKTV/Services/Service/ChatGptService.cs
@@ -48,8 +48,8 @@ public class ChatGptService : IChatGptService
             throw new ArgumentException($"Error in {nameof(TranslateLyricsAsync)}: At least one of romanize or translate must be true.");
         }
         string prompt = $@"
-You are a helpful assistant that translates LRC formatted lyrics into an English translation (if needed) and, if needed, a romanized version (using the English alphabet) while maintaing the same format.
-Is romanization needed: {(romanize ? "Yes" : "No")}
+        You are a helpful assistant that translates LRC formatted lyrics into an English translation (if needed) and, if needed, a romanized version (using the English alphabet) while maintaining the same format.
+        Is romanization needed: {(romanize ? "Yes" : "No")}
 Is translation needed: {(translate ? "Yes" : "No")}
 Notice the only exception to this is if the original lyrics are already in English, in which case no translation or romanization is needed. This occurs if language code is UNK, correct to EN if it is english and null out romanization and translation.
 If not needed, have the json response for the section be null or not there. Maintain the LRC text format timestamps exactly in the responses.

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -221,13 +221,13 @@ public class FullSongService : IFullSongService
         //Add residual information (kinda messy)
         if (lyricsDto != null)
         {
-            if (lyricsDto.TrackName is not null && !song.AlternateTitles.Contains(lyricsDto.TrackName.ToLowerInvariant()) && !string.IsNullOrWhiteSpace(lyricsDto.TrackName))
+            if (!string.IsNullOrWhiteSpace(lyricsDto.TrackName) && !song.AlternateTitles.Any(alt => alt.Equals(lyricsDto.TrackName, StringComparison.OrdinalIgnoreCase)))
             {
-                song.AlternateTitles.Add(lyricsDto.TrackName.ToLowerInvariant());
+                song.AlternateTitles.Add(lyricsDto.TrackName);
             }
-            if (lyricsDto.ArtistName is not null && !song.FeaturedArtists.Contains(lyricsDto.ArtistName.ToLowerInvariant()) && !string.IsNullOrWhiteSpace(lyricsDto.ArtistName))
+            if (!string.IsNullOrWhiteSpace(lyricsDto.ArtistName) && !song.FeaturedArtists.Any(artist => artist.Equals(lyricsDto.ArtistName, StringComparison.OrdinalIgnoreCase)))
             {
-                song.FeaturedArtists.Add(lyricsDto.ArtistName.ToLowerInvariant());
+                song.FeaturedArtists.Add(lyricsDto.ArtistName);
             }
             if (lyricsDto.Id != 0 && song.LrcId != lyricsDto.Id)
             {
@@ -242,11 +242,11 @@ public class FullSongService : IFullSongService
                 song.PlainLyrics = lyricsDto.PlainLyrics;
             }
         }
-        if (title is not null && !song.AlternateTitles.Contains(title) && !string.IsNullOrWhiteSpace(title))
+        if (!string.IsNullOrWhiteSpace(title) && !song.AlternateTitles.Any(alt => alt.Equals(title, StringComparison.OrdinalIgnoreCase)))
         {
             song.AlternateTitles.Add(title);
         }
-        if (artist is not null && !song.FeaturedArtists.Contains(artist) && !string.IsNullOrWhiteSpace(artist))
+        if (!string.IsNullOrWhiteSpace(artist) && !song.FeaturedArtists.Any(alt => alt.Equals(artist, StringComparison.OrdinalIgnoreCase)))
         {
             if (CompareUtils.CompareArtistFuzzyScore(song.Artist, artist) > 75) //filters out youtube personal channels
             {

--- a/ChordKTV/Services/Service/YouTubeClientService.cs
+++ b/ChordKTV/Services/Service/YouTubeClientService.cs
@@ -168,12 +168,12 @@ public class YouTubeApiClientService : IYouTubeClientService, IDisposable
         //reference https://developers.google.com/youtube/v3/docs/search/list#.net
 
         SearchResource.ListRequest searchRequest = _youTubeSearchService.Search.List("snippet");
-        searchRequest.Q = $"{title} {artist} {album ?? ""}";
+        searchRequest.Q = $"{title} {artist}"; //no album for now, as youtube search api is kinda lobotomized, will return no result
         searchRequest.Type = "video";
-        searchRequest.MaxResults = 4; //more simple, maybe expand in future to allow users to choose, 2 groups based on relevancy sort
+        searchRequest.MaxResults = 10; //more simple, maybe expand in future to allow users to choose, 2 groups based on relevancy sort
 
         //https://stackoverflow.com/a/17738994/17621099 category type 10 is music for all regions where allowed
-        searchRequest.VideoCategoryId = "10";
+        // searchRequest.VideoCategoryId = "10";
 
         SearchListResponse searchResponse = await searchRequest.ExecuteAsync();
         //first search response item that has video id


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Fixed Prompt to be more reliable for translation and romanization. Also allowed language code revision, which successfully detected and fixed DE (german) -> JP (Japanese) for title only search Renai Circulation, as genius currently returns a german cover for metadata.

Should have minimal UNK language codes now

Alternate title and artist redundancy fix and better matching on the side. 
## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #113 
![image](https://github.com/user-attachments/assets/325793d6-ffc6-4482-8a63-cc63fb2c5a32)
Fixes #109 
Fixes #114 
Language Code Fix for english should keep translation and romanization all the same

Fixes #127 
![image](https://github.com/user-attachments/assets/5bd80160-d164-46c3-a858-4f5be4b28e91)


## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->
![image](https://github.com/user-attachments/assets/b54bb599-3f00-49dd-be5c-76aec5a20f53)
![image](https://github.com/user-attachments/assets/95027b24-064b-4d18-82ca-7f05d51d51fb)
![image](https://github.com/user-attachments/assets/ee923860-bebd-4fbe-90b4-2f90cdcb78fe)
![image](https://github.com/user-attachments/assets/c2dcf8ef-e1f0-4d12-9118-3407e8ae5280)
