### PR TITLE
Reapply "LRCSearch: Add Artist and Title Alternates to Return DTO"

### DIFF
--- a/ChordKTV/Dtos/LrcLyricsDto.cs
+++ b/ChordKTV/Dtos/LrcLyricsDto.cs
@@ -14,4 +14,6 @@ public class LrcLyricsDto
     public string? SyncedLyrics { get; set; }
     public string? RomanizedPlainLyrics { get; set; }
     public string? RomanizedSyncedLyrics { get; set; }
+    public List<string> AlternateTitles { get; set; } = [];
+    public List<string> AlternateArtists { get; set; } = [];
 }

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -155,6 +155,27 @@ public class FullSongService : IFullSongService
                 song.Title = lyricsDto.TrackName ?? title ?? song.Title;
                 song.Artist = lyricsDto.ArtistName ?? artist ?? song.Artist;
                 song.LrcLyrics = lyricsDto.SyncedLyrics;
+                // Add new alternates from LRC search
+                if (lyricsDto.AlternateTitles?.Count > 0)
+                {
+                    foreach (string altTitle in lyricsDto.AlternateTitles)
+                    {
+                        if (!song.AlternateTitles.Any(title => string.Equals(title, altTitle, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            song.AlternateTitles.Add(altTitle);
+                        }
+                    }
+                }
+                if (lyricsDto.AlternateArtists?.Count > 0)
+                {
+                    foreach (string altArtist in lyricsDto.AlternateArtists)
+                    {
+                        if (!song.FeaturedArtists.Any(artist => string.Equals(artist, altArtist, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            song.FeaturedArtists.Add(altArtist);
+                        }
+                    }
+                }
             }
             else //create if we dont find in genius at all
             {
@@ -168,6 +189,8 @@ public class FullSongService : IFullSongService
                     LrcId = lyricsDto.Id,
                     RomLrcId = lyricsDto.RomanizedId,
                     LrcRomanizedLyrics = lyricsDto.RomanizedSyncedLyrics,
+                    AlternateTitles = lyricsDto.AlternateTitles.Select(t => t.ToLowerInvariant()).ToList(),
+                    FeaturedArtists = lyricsDto.AlternateArtists.Select(a => a.ToLowerInvariant()).ToList(),
                     GeniusMetaData = new GeniusMetaData { }
                 };
                 songCreate = true;

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -64,7 +64,6 @@ public class LrcService : ILrcService
         }
 
         //We fuzzy order to add layer of confidence
-        //TODO: remove null check if #70 issue resolved
         searchResults = searchResults
             .OrderByDescending(ele => CompareUtils
             .CompareWeightedFuzzyScore(title, ele.TrackName ?? "", artist, ele.ArtistName, duration, ele.Duration))
@@ -77,6 +76,30 @@ public class LrcService : ILrcService
                 !string.IsNullOrEmpty(ele.PlainLyrics) &&
                 !string.IsNullOrEmpty(ele.SyncedLyrics));
         }
+
+        // Collect alternate titles and artists from search results
+        if (lyricsDtoMatch != null && searchResults.Count > 0)
+        {
+            // Get unique titles and artists that meet minimum similarity threshold
+            foreach (LrcLyricsDto result in searchResults.Take(5)) // Limit to top 5 results
+            {
+                // Only add titles if the artists match with high confidence
+                if (!string.IsNullOrWhiteSpace(result.TrackName) &&
+                    !lyricsDtoMatch.AlternateTitles.Contains(result.TrackName) &&
+                    CompareUtils.CompareArtistFuzzyScore(artist, result.ArtistName, lyricsDtoMatch.ArtistName, 90) > 80)
+                {
+                    lyricsDtoMatch.AlternateTitles.Add(result.TrackName);
+                }
+
+                // For artists, keep the existing high threshold check
+                if (!string.IsNullOrWhiteSpace(result.ArtistName) &&
+                    CompareUtils.CompareArtistFuzzyScore(artist, result.ArtistName, lyricsDtoMatch.ArtistName, 90) > 80)
+                {
+                    lyricsDtoMatch.AlternateArtists.Add(result.ArtistName);
+                }
+            }
+        }
+
         if (lyricsDtoMatch == null)
         {
             //if we fail to find even a single match, just grab first entry if it exists


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Added alternate titles and artists to LrcLyricsDto and updated the search process to collect these variations. This helps track different versions of titles/artists found during romanization searches, which improves our matching capabilities in the database.

Changes made:

Added AlternateTitles and AlternateArtists lists to LrcLyricsDto
Modified LrcService to collect top 5 similar titles/artists using existing fuzzy matching (threshold >80)
Updated FullSongService to store these alternates in the database

## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #76 

## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
