### PR TITLE
null duration json serialization LRC, gpt prompt enhance

### DIFF
--- a/ChordKTV/Dtos/LrcLyricsDto.cs
+++ b/ChordKTV/Dtos/LrcLyricsDto.cs
@@ -8,7 +8,7 @@ public class LrcLyricsDto
     public string? TrackName { get; set; }
     public string? ArtistName { get; set; }
     public string? AlbumName { get; set; }
-    public float Duration { get; set; }
+    public float? Duration { get; set; }
     public bool Instrumental { get; set; }
     public string? PlainLyrics { get; set; }
     public string? SyncedLyrics { get; set; }

--- a/ChordKTV/Services/Service/ChatGptService.cs
+++ b/ChordKTV/Services/Service/ChatGptService.cs
@@ -62,6 +62,7 @@ Input Lyrics:
 Remember if the original lyrics are already in English, no translation or romanization is needed and ignore the is needed clauses above.
 The lyrics input contains timestamps LRC Format. Do not change any timestamps or the formatting.
 Ensure that the output follows the expected JSON structure and also escape all quotation marks within the translation/romanization to be able to be json parsed.
+Make sure apostrophies in translation and romanization are escaped as well.
 Output Format:
 {{
     ""romanizedLyrics"": ""<romanized lyrics in LRC format, if applicable or null>"",

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -122,7 +122,11 @@ public class FullSongService : IFullSongService
             {
                 song.LrcId = lrcLyricsDto.Id;
                 song.LrcLyrics = lrcLyricsDto.SyncedLyrics;
-                song.Duration = TimeSpan.FromSeconds(lrcLyricsDto.Duration); //overwrite since we overwrite lyrics above too
+                if (lrcLyricsDto.Duration != null)
+                {
+                    //overwrite duration if we have a better one
+                    song.Duration = TimeSpan.FromSeconds(lrcLyricsDto.Duration.Value);
+                }
             }
         }
 
@@ -184,11 +188,12 @@ public class FullSongService : IFullSongService
             }
             else //create if we dont find in genius at all
             {
+
                 song = new Song
                 {
                     Title = lrcLyricsDto.TrackName ?? title ?? "Unknown",
                     Artist = lrcLyricsDto.ArtistName ?? artist ?? "Unknown",
-                    Duration = lrcLyricsDto.Duration > 0 ? TimeSpan.FromSeconds(lrcLyricsDto.Duration) : duration,
+                    Duration = lrcLyricsDto.Duration != null ? TimeSpan.FromSeconds(lrcLyricsDto.Duration.Value) : duration,
                     LrcLyrics = lrcLyricsDto.SyncedLyrics,
                     PlainLyrics = lrcLyricsDto.PlainLyrics,
                     LrcId = lrcLyricsDto.Id,

--- a/ChordKTV/Services/Service/GeniusService.cs
+++ b/ChordKTV/Services/Service/GeniusService.cs
@@ -189,7 +189,8 @@ public class GeniusService : IGeniusService
         if (result != null)
         {
             result = await EnrichSongDetailsAsync(result);
-            _logger.LogInformation("Found matching song. Adding to cache.");
+            _logger.LogInformation("Found matching song. Adding to cache. Title: '{Title}', Artist: '{Artist}'",
+                result.Title, result.Artist);
             await _songRepo.AddSongAsync(result);
             await _songRepo.SaveChangesAsync();
         }


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Was a Json Parsing issue with LRC, getting null durations. Resolved by fixing dto and downstream null checks. Also enhance gpt prompt for a similar issue. 

## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #152 

## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->
![image](https://github.com/user-attachments/assets/34b6238d-eead-4891-8666-b71c9847749b)

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
