### PR TITLE
Backend genius db save remove, add ID db Query matching

### DIFF
--- a/ChordKTV/Data/Api/SongData/ISongRepo.cs
+++ b/ChordKTV/Data/Api/SongData/ISongRepo.cs
@@ -11,6 +11,8 @@ public interface ISongRepo
     public Task<Song?> GetSongAsync(string name, string artist);
     public Task<Song?> GetSongAsync(string name, string artist, string albumName);
     public Task<List<Song>> GetAllSongsAsync();
-    public Task<Song?> GetSongByGeniusIdAsync(int geniusId);
     public Task<Song?> GetSongByIdAsync(Guid id);
+    public Task<Song?> GetSongByGeniusIdAsync(int geniusId);
+    public Task<Song?> GetSongByLrcIdAsync(int lrcId);
+    public Task<Song?> GetSongByRomanizedLrcIdAsync(int romLrcId);
 }

--- a/ChordKTV/Data/Repo/SongData/SongRepo.cs
+++ b/ChordKTV/Data/Repo/SongData/SongRepo.cs
@@ -57,19 +57,20 @@ public class SongRepo : ISongRepo
 
         _logger.LogDebug("Looking up song in cache. Name: {Name}, Artist: {Artist}", normalizedName, normalizedArtist);
 
-        Song? result = await _context.Songs
+        List<Song> songs = await _context.Songs
             .Include(s => s.GeniusMetaData)
             .Include(s => s.Albums)
-            .Where(s =>
-                // Filter by normalized title or alternate titles
-                (EF.Functions.Collate(s.Title.Trim().Replace(" ", ""), "NOCASE") == normalizedName ||
-                s.AlternateTitles.Any(n => EF.Functions.Collate(n.Trim().Replace(" ", ""), "NOCASE") == normalizedName))
-                &&
-                // Filter by artist or featured artists
-                (EF.Functions.Collate(s.Artist.Trim(), "NOCASE").StartsWith(normalizedArtist, StringComparison.OrdinalIgnoreCase) ||
-                s.FeaturedArtists.Any(a => EF.Functions.Collate(a.Trim(), "NOCASE").StartsWith(normalizedArtist, StringComparison.OrdinalIgnoreCase)))
-            )
-            .FirstOrDefaultAsync();
+            .ToListAsync();
+
+        //TODO try ef query instead of in memory query (will perhaps cause scaling issues later?)
+        // Use string.Equals(..., StringComparison.OrdinalIgnoreCase) and the StartsWith overload with StringComparison
+        Song? result = songs.FirstOrDefault(s =>
+            (string.Equals(s.Title.Trim().Replace(" ", ""), normalizedName, StringComparison.OrdinalIgnoreCase) ||
+             s.AlternateTitles.Any(n =>
+                 string.Equals(n.Trim().Replace(" ", ""), normalizedName, StringComparison.OrdinalIgnoreCase))) &&
+            (s.Artist.Trim().StartsWith(normalizedArtist, StringComparison.OrdinalIgnoreCase) ||
+             s.FeaturedArtists.Any(a => a.Trim().StartsWith(normalizedArtist, StringComparison.OrdinalIgnoreCase)))
+        );
 
         _logger.LogDebug("Cache lookup result: {Result}", result != null ? "Found" : "Not found");
 

--- a/ChordKTV/Data/Repo/SongData/SongRepo.cs
+++ b/ChordKTV/Data/Repo/SongData/SongRepo.cs
@@ -57,7 +57,6 @@ public class SongRepo : ISongRepo
 
         _logger.LogDebug("Looking up song in cache. Name: {Name}, Artist: {Artist}", normalizedName, normalizedArtist);
 
-        // Retrieve songs from the database first
         Song? result = await _context.Songs
             .Include(s => s.GeniusMetaData)
             .Include(s => s.Albums)
@@ -72,7 +71,6 @@ public class SongRepo : ISongRepo
             )
             .FirstOrDefaultAsync();
 
-        // Use string.Equals(..., StringComparison.OrdinalIgnoreCase) and the StartsWith overload with StringComparison
         _logger.LogDebug("Cache lookup result: {Result}", result != null ? "Found" : "Not found");
 
         return result;
@@ -91,6 +89,14 @@ public class SongRepo : ISongRepo
         return await _context.Songs.ToListAsync();
     }
 
+    public async Task<Song?> GetSongByIdAsync(Guid id)
+    {
+        return await _context.Songs
+            .Include(s => s.GeniusMetaData)
+            .Include(s => s.Albums)
+            .FirstOrDefaultAsync(s => s.Id == id);
+    }
+
     public async Task<Song?> GetSongByGeniusIdAsync(int geniusId)
     {
         return await _context.Songs
@@ -98,11 +104,18 @@ public class SongRepo : ISongRepo
             .FirstOrDefaultAsync(s => s.GeniusMetaData.GeniusId == geniusId);
     }
 
-    public async Task<Song?> GetSongByIdAsync(Guid id)
+    public async Task<Song?> GetSongByLrcIdAsync(int lrcId)
     {
         return await _context.Songs
             .Include(s => s.GeniusMetaData)
             .Include(s => s.Albums)
-            .FirstOrDefaultAsync(s => s.Id == id);
+            .FirstOrDefaultAsync(s => s.LrcId == lrcId);
+    }
+    public async Task<Song?> GetSongByRomanizedLrcIdAsync(int romLrcId)
+    {
+        return await _context.Songs
+            .Include(s => s.GeniusMetaData)
+            .Include(s => s.Albums)
+            .FirstOrDefaultAsync(s => s.RomLrcId == romLrcId);
     }
 }

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -225,7 +225,7 @@ public class FullSongService : IFullSongService
             }
             if (dbSong is not null)
             {
-                _logger.LogWarning("Found song in db with same LRC/Genius ID, skipping LLM processing");
+                _logger.LogInformation("Found song in db with same LRC/Genius ID, skipping LLM processing");
                 return _mapper.Map<FullSongResponseDto>(dbSong);
             }
         }

--- a/ChordKTV/Services/Service/GeniusService.cs
+++ b/ChordKTV/Services/Service/GeniusService.cs
@@ -189,10 +189,8 @@ public class GeniusService : IGeniusService
         if (result != null)
         {
             result = await EnrichSongDetailsAsync(result);
-            _logger.LogInformation("Found matching song. Adding to cache. Title: '{Title}', Artist: '{Artist}'",
+            _logger.LogInformation("Found matching song. Title: '{Title}', Artist: '{Artist}'",
                 result.Title, result.Artist);
-            await _songRepo.AddSongAsync(result);
-            await _songRepo.SaveChangesAsync();
         }
         else
         {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Fix the issue with cached songs not being pulled due to user input mismatching data in database. For example when we use a youtube video which has a personal channel name that doesn't match artist. Genius now doesn't create the entry in the db, full stack service will check the LRC id, Romanized LRC id, and then Genius ID for db hits after correlated artist + title is found, if not continues regular process and then adds to db at end now.

It essentially saves time so we don't double process LLM and also better prevents the duplication of data within the database.
## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #126 

## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->
![image](https://github.com/user-attachments/assets/fb436c05-b4cf-42a5-b871-7693b6a2e6a6)

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
