### PR TITLE
Backend genius search refinement fixes

### DIFF
--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -62,13 +62,19 @@ public class FullSongService : IFullSongService
             Dictionary<string, VideoDetails> videoDict = await _youTubeClientService.GetVideosDetailsAsync([youtubeId]);
             if (videoDict.Count == 0)
             {
-                _logger.LogWarning("GetVideosDetailsAsync: Youtube video not found for id: {YoutubeId}", youtubeId);
+                _logger.LogError("GetVideosDetailsAsync: Youtube video not found for id: {YoutubeId}", youtubeId);
             }
             else
             {
                 videoDetails = videoDict[youtubeId];
-                title ??= videoDetails.Title;
-                artist ??= videoDetails.ChannelTitle;
+                if (string.IsNullOrWhiteSpace(title))
+                {
+                    title = videoDetails.Title;
+                }
+                if (string.IsNullOrWhiteSpace(artist))
+                {
+                    artist = videoDetails.ChannelTitle;
+                }
                 duration ??= videoDetails.Duration;
             }
         }

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -96,7 +96,7 @@ public class FullSongService : IFullSongService
                     foreach (CandidateSongInfo candidate in candidateSongInfoList.Candidates)
                     {
                         song = await _geniusService.GetSongByArtistTitleAsync(candidate.Title, candidate.Artist, lyrics);
-                        if (song is not null)
+                        if (song is not null || (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(artist)))
                         {
                             title = candidate.Title;
                             artist = candidate.Artist;

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -237,10 +237,15 @@ public class FullSongService : IFullSongService
         }
 
         // check if lyrics are translated, don't need to translate/romanize if alr english
-        if (song.GeniusMetaData.Language.Equals(LanguageCode.EN))
+        // Genius LangCode could be wrong, so we explicitly check romanization too.
+        if (song.GeniusMetaData.Language.Equals(LanguageCode.EN) && LanguageUtils.IsRomanizedText(song.LrcLyrics))
         {
             song.LrcTranslatedLyrics ??= lrcLyricsDto?.SyncedLyrics;
             song.LrcRomanizedLyrics ??= lrcLyricsDto?.SyncedLyrics;
+        }
+        else if (song.GeniusMetaData.Language.Equals(LanguageCode.EN))
+        {
+            _logger.LogError("Genius Language code is English but lyrics are romanized, for song: '{Title}' by '{Artist}'", song.Title, song.Artist);
         }
         song.LrcRomanizedLyrics ??= lrcLyricsDto?.RomanizedSyncedLyrics;
 

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -245,8 +245,7 @@ public class FullSongService : IFullSongService
         }
         else if (song.GeniusMetaData.Language.Equals(LanguageCode.EN))
         {
-            _logger.LogError("Genius Language code is English but lyrics are romanized, for song: '{Title}' by '{Artist}'", song.Title, song.Artist);
-        }
+            _logger.LogError("Genius Language code is English but lyrics are not romanized as expected, for song: '{Title}' by '{Artist}'", song.Title, song.Artist);
         song.LrcRomanizedLyrics ??= lrcLyricsDto?.RomanizedSyncedLyrics;
 
         //check if lyrics are romanized (note that we do not check LRC Lib for romanization if db alr has synced lyrics)

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -246,6 +246,7 @@ public class FullSongService : IFullSongService
         else if (song.GeniusMetaData.Language.Equals(LanguageCode.EN))
         {
             _logger.LogError("Genius Language code is English but lyrics are not romanized as expected, for song: '{Title}' by '{Artist}'", song.Title, song.Artist);
+        }
         song.LrcRomanizedLyrics ??= lrcLyricsDto?.RomanizedSyncedLyrics;
 
         //check if lyrics are romanized (note that we do not check LRC Lib for romanization if db alr has synced lyrics)

--- a/ChordKTV/Services/Service/GeniusService.cs
+++ b/ChordKTV/Services/Service/GeniusService.cs
@@ -41,42 +41,6 @@ public class GeniusService : IGeniusService
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
     }
 
-    // private sealed class SearchMatch
-    // {
-    //     public GeniusResult Result { get; set; } = null!;
-    //     public int TitleScore { get; set; }
-    //     public int ArtistScore { get; set; }
-    //     public int TotalScore => TitleScore + ArtistScore;
-    // }
-
-    // private static SearchMatch ScoreMatch(GeniusResult result, string queryTitle, string? queryArtist)
-    // {
-    //     // Calculate title score
-    //     string normalizedResultTitle = result.Title.ToLower(CultureInfo.CurrentCulture);
-    //     string normalizedQueryTitle = queryTitle.ToLower(CultureInfo.CurrentCulture);
-
-    //     int exactTitleScore = Fuzz.Ratio(normalizedResultTitle, normalizedQueryTitle);
-    //     bool containsTitle = normalizedResultTitle.Contains(normalizedQueryTitle, StringComparison.OrdinalIgnoreCase);
-    //     int titleScore = containsTitle ? Math.Max(exactTitleScore, 85) : exactTitleScore;
-
-    //     // Calculate artist score only if provided (used for ranking, not filtering)
-    //     int artistScore = 0;
-    //     if (!string.IsNullOrWhiteSpace(queryArtist))
-    //     {
-    //         artistScore = Fuzz.Ratio(
-    //             result.PrimaryArtistNames.ToLower(CultureInfo.CurrentCulture),
-    //             queryArtist.ToLower(CultureInfo.CurrentCulture)
-    //         );
-    //     }
-
-    //     return new SearchMatch
-    //     {
-    //         Result = result,
-    //         TitleScore = titleScore,
-    //         ArtistScore = artistScore
-    //     };
-    // }
-
     /// <summary>
     /// Helper to query Genius using the given search query and compare results with the provided fuzzy criteria
     /// </summary>

--- a/ChordKTV/Services/Service/GeniusService.cs
+++ b/ChordKTV/Services/Service/GeniusService.cs
@@ -130,13 +130,14 @@ public class GeniusService : IGeniusService
 
             //TODO: Later refactor maybe and return all the hit list to maybe be selectable options for user (to refine search query)
             //Do a subcheck to ensure it meets min artist requirements
+
             GeniusHit? bestMatch = matches
                 .FirstOrDefault(h => CompareUtils
                     .CompareArtistFuzzyScore(fuzzyArtist, h.Result.PrimaryArtistNames) > 90);
 
             if (bestMatch?.Result == null)
             {
-                _logger.LogWarning("SearchGenius: No matches found for query: {SearchQuery} ; matching with Title: {FuzzyTitle} ; Artist: {FuzzyArtist}", searchQuery, fuzzyTitle, fuzzyArtist); );
+                _logger.LogWarning("SearchGenius: No matches found for query: {SearchQuery} ; matching with Title: {FuzzyTitle} ; Artist: {FuzzyArtist}", searchQuery, fuzzyTitle, fuzzyArtist);
                 return null;
             }
             return await MapGeniusResultToSongAsync(bestMatch.Result);
@@ -150,6 +151,11 @@ public class GeniusService : IGeniusService
 
     public async Task<Song?> GetSongByArtistTitleAsync(string? title, string? artist, string? lyrics, bool forceRefresh = false)
     {
+        if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(artist) && string.IsNullOrWhiteSpace(lyrics))
+        {
+            return null;
+        }
+
         _logger.LogInformation("Starting song search - Title: '{Title}', Artist: '{Artist}', ForceRefresh: {ForceRefresh}",
             title, artist, forceRefresh);
 
@@ -197,7 +203,7 @@ public class GeniusService : IGeniusService
         }
         else
         {
-            _logger.LogWarning("No matching song found after all search attempts");
+            _logger.LogWarning("GeniusService: GetSongByArtistTitleAsync: No matching song found after all search attempts");
         }
 
         return result;

--- a/ChordKTV/Services/Service/GeniusService.cs
+++ b/ChordKTV/Services/Service/GeniusService.cs
@@ -119,8 +119,6 @@ public class GeniusService : IGeniusService
                     hit.Result.Title, hit.Result.PrimaryArtistNames);
             }
 
-            // const int minTitleScore = 50;  // Renamed to follow C# naming conventions
-
             // Update the score check
             List<GeniusHit> matches = searchResponse.Response.Hits
                 .Where(h => h.Result != null)
@@ -130,10 +128,20 @@ public class GeniusService : IGeniusService
 
             //TODO: Later refactor maybe and return all the hit list to maybe be selectable options for user (to refine search query)
             //Do a subcheck to ensure it meets min artist requirements
+            GeniusHit? bestMatch = null;
+            if (!string.IsNullOrWhiteSpace(fuzzyArtist))
+            {
+                bestMatch = matches
+                    .FirstOrDefault(h => CompareUtils
+                        .CompareArtistFuzzyScore(fuzzyArtist, h.Result.PrimaryArtistNames) > 90);
+            }
+            else
+            {   //if no artist is provided, we can use the title match, looser, still testing, use a custom title match if needed
+                bestMatch = matches
+                    .FirstOrDefault(h => CompareUtils
+                        .CompareArtistFuzzyScore(fuzzyTitle, h.Result.Title, bonusWeight: 0.32) > 80);
+            }
 
-            GeniusHit? bestMatch = matches
-                .FirstOrDefault(h => CompareUtils
-                    .CompareArtistFuzzyScore(fuzzyArtist, h.Result.PrimaryArtistNames) > 90);
 
             if (bestMatch?.Result == null)
             {

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -67,7 +67,7 @@ public class LrcService : ILrcService
         searchResults = searchResults
             .Where(ele => ele.Duration != null)
             .OrderByDescending(ele => CompareUtils
-            .CompareWeightedFuzzyScore(title, ele.TrackName ?? "", artist, ele.ArtistName, duration, ele.Duration!.Value))
+                .CompareWeightedFuzzyScore(title, ele.TrackName ?? "", artist, ele.ArtistName, duration, ele.Duration!.Value))
             .ToList();
 
         // Get the first result with time-synced lyrics

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -33,6 +33,7 @@ public class LrcService : ILrcService
         }
         else
         {
+            _logger.LogError("Error in {MethodName}: At least title be provided", nameof(GetAllLrcLibLyricsAsync));
             throw new ArgumentException($"Error in {nameof(GetAllLrcLibLyricsAsync)}: At least title be provided");
         }
         if (!string.IsNullOrEmpty(artist))


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Made Genius Search more robust, swapped out basic comparison for compare utils function that was used for LRC. Added it for Title matching when artist not available. Other minor bug fixes in full integration to ensure youtube data was being pulled and written properly to variables.

## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #112 
Fixes #153 
Fixes #154  (Added checking conditions and explicit romanization check on top of genius code check), might actually have to do gpt processing if we are still finding errors. But the other changes in this PR to reinforce the search should prevent this. Reopen if needed.

## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->
SS for #112 

Previously, genius was returning a same name but bad artist. 
![image](https://github.com/user-attachments/assets/aeacdb4d-57b7-4755-a679-3019befde89d)

Small bug with null check vs blank string check on youtube fix
![image](https://github.com/user-attachments/assets/c08097fd-05ae-44a1-9e26-f9dc01022a8f)

SS for #153 
Had to add title checking when artist is empty. Used compare utils author checking with different weights for titles. Allows genius to return null on lower confidence so LRC title + artist can take over. (Previously null artist returned a high null weight score, allowing wrong genius entry path pass through).
![image](https://github.com/user-attachments/assets/f00a26cb-3992-4981-946c-78a554f68995)

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
