### PR TITLE
artist checking LRC in best results grabbing

### DIFF
--- a/ChordKTV/Services/Service/ChatGptService.cs
+++ b/ChordKTV/Services/Service/ChatGptService.cs
@@ -140,7 +140,7 @@ You are a helpful assistant that translates LRC formatted lyrics into an English
         }
 
         //Try parsing language code from string
-        if (Enum.TryParse(translatedSongLyrics.LanguageCode, out LanguageCode parsedLanguageCode))
+        if (Enum.TryParse(translatedSongLyrics.LanguageCode.ToUpperInvariant(), out LanguageCode parsedLanguageCode))
         {
             if (parsedLanguageCode == LanguageCode.UNK)
             {

--- a/ChordKTV/Services/Service/ChatGptService.cs
+++ b/ChordKTV/Services/Service/ChatGptService.cs
@@ -321,7 +321,7 @@ You are a helpful assistant that translates LRC formatted lyrics into an English
     public async Task<CandidateSongInfoListResponse> GetCandidateSongInfosAsync(string videoTitle, string channelName)
     {
         string prompt = $@"
-        Extract the song title and artist from the following YouTube video title and channel name.
+        Extract the song title and artist from the following YouTube video or Genius Source title and channel name.
         Input:
         Video Title: ""{videoTitle}""
         Channel Name: ""{channelName}""

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -112,6 +112,21 @@ public class FullSongService : IFullSongService
                 }
             }
         }
+        else if (!string.IsNullOrWhiteSpace(lyrics) && string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(artist))
+        {
+            //since there is a high chance people search with romanization, which returns like genius romanization as artist (basically unclean title), use candidate cleaning like with youtube
+            candidateSongInfoList = await _chatGptService.GetCandidateSongInfosAsync(song.Title, song.Artist);
+            foreach (CandidateSongInfo candidate in candidateSongInfoList.Candidates)
+            {
+                song = await _geniusService.GetSongByArtistTitleAsync(candidate.Title, candidate.Artist, lyrics);
+                if (song is not null || (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(artist)))
+                {
+                    title = candidate.Title;
+                    artist = candidate.Artist;
+                    break;
+                }
+            }
+        }
 
         //Gets lyrics from lrc service if not already present
         LrcLyricsDto? lrcLyricsDto = null;

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -158,12 +158,13 @@ public class FullSongService : IFullSongService
             lrcLyricsDto = await _lrcService.GetAllLrcLibLyricsAsync(title, artist, null, (float?)duration?.TotalSeconds);
             if (lrcLyricsDto is null || string.IsNullOrWhiteSpace(lrcLyricsDto.SyncedLyrics)) //not found anywhere
             {
-                if (candidateSongInfoList is null && videoDetails is not null) //genius title artist failed but youtube details are there to try again
+                if (videoDetails is not null) //genius title artist failed but youtube details are there to try again
                 {
                     _logger.LogWarning("2nd attempt Failed to get lyrics from LRC lib for '{Title}' by '{Artist}', Duration: {Duration}: attempting candidate gpt list", title, artist, duration);
-                    candidateSongInfoList = await _chatGptService.GetCandidateSongInfosAsync(videoDetails.Title, videoDetails.ChannelTitle);
+                    candidateSongInfoList ??= await _chatGptService.GetCandidateSongInfosAsync(videoDetails.Title, videoDetails.ChannelTitle);
                     foreach (CandidateSongInfo candidate in candidateSongInfoList.Candidates)
                     {
+                        _logger.LogInformation("Testing Candidate for LRC Lib: '{Title}' by '{Artist}'", candidate.Title, candidate.Artist);
                         lrcLyricsDto = await _lrcService.GetAllLrcLibLyricsAsync(candidate.Title, candidate.Artist, null, (float?)duration?.TotalSeconds);
                         if (lrcLyricsDto is not null && !string.IsNullOrWhiteSpace(lrcLyricsDto.SyncedLyrics))
                         {

--- a/ChordKTV/Services/Service/FullSongService.cs
+++ b/ChordKTV/Services/Service/FullSongService.cs
@@ -158,9 +158,9 @@ public class FullSongService : IFullSongService
             lrcLyricsDto = await _lrcService.GetAllLrcLibLyricsAsync(title, artist, null, (float?)duration?.TotalSeconds);
             if (lrcLyricsDto is null || string.IsNullOrWhiteSpace(lrcLyricsDto.SyncedLyrics)) //not found anywhere
             {
-                _logger.LogWarning("2nd attempt Failed to get lyrics from LRC lib for '{Title}' by '{Artist}', Duration: {Duration}: attempting candidate gpt list", title, artist, duration);
                 if (candidateSongInfoList is null && videoDetails is not null) //genius title artist failed but youtube details are there to try again
                 {
+                    _logger.LogWarning("2nd attempt Failed to get lyrics from LRC lib for '{Title}' by '{Artist}', Duration: {Duration}: attempting candidate gpt list", title, artist, duration);
                     candidateSongInfoList = await _chatGptService.GetCandidateSongInfosAsync(videoDetails.Title, videoDetails.ChannelTitle);
                     foreach (CandidateSongInfo candidate in candidateSongInfoList.Candidates)
                     {

--- a/ChordKTV/Services/Service/GeniusService.cs
+++ b/ChordKTV/Services/Service/GeniusService.cs
@@ -84,11 +84,20 @@ public class GeniusService : IGeniusService
             }
 
             // Update the score check
-            List<GeniusHit> matches = searchResponse.Response.Hits
+            Dictionary<GeniusHit, int> hitScores = searchResponse.Response.Hits
                 .Where(h => h.Result != null)
-                .OrderByDescending(h => CompareUtils
-                .CompareWeightedFuzzyScore(fuzzyTitle ?? "", h.Result.Title, fuzzyArtist ?? "", h.Result.PrimaryArtistNames, 0, 0))
+                .ToDictionary(
+                    h => h,
+                    h => CompareUtils.CompareWeightedFuzzyScore(fuzzyTitle ?? "", h.Result.Title, fuzzyArtist ?? "", h.Result.PrimaryArtistNames, 0, 0)
+                );
+
+            //Order and filter titles
+            List<GeniusHit> matches = hitScores
+                .Where(dic => dic.Value > 70)
+                .OrderByDescending(dic => dic.Value)
+                .Select(dic => dic.Key)
                 .ToList();
+
 
             //TODO: Later refactor maybe and return all the hit list to maybe be selectable options for user (to refine search query)
             //Do a subcheck to ensure it meets min artist requirements

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -74,10 +74,20 @@ public class LrcService : ILrcService
         // Get the first result with time-synced lyrics
         if (string.IsNullOrWhiteSpace(lyricsDtoMatch?.SyncedLyrics))
         {
-            lyricsDtoMatch = searchResults.FirstOrDefault(ele =>
-                !string.IsNullOrEmpty(ele.PlainLyrics) &&
-                !string.IsNullOrEmpty(ele.SyncedLyrics) &&
-                CompareUtils.CompareArtistFuzzyScore(artist, ele.ArtistName) > 70);
+            if (!string.IsNullOrWhiteSpace(artist))
+            {
+                lyricsDtoMatch = searchResults.FirstOrDefault(ele =>
+                    !string.IsNullOrEmpty(ele.PlainLyrics) &&
+                    !string.IsNullOrEmpty(ele.SyncedLyrics) &&
+                    CompareUtils.CompareArtistFuzzyScore(artist, ele.ArtistName) > 70);
+            }
+            else
+            { //the case where title only search without artist, want a more strict title match instead
+                lyricsDtoMatch = searchResults.FirstOrDefault(ele =>
+                    !string.IsNullOrEmpty(ele.PlainLyrics) &&
+                    !string.IsNullOrEmpty(ele.SyncedLyrics) &&
+                    CompareUtils.CompareWeightedFuzzyScore(title, ele.TrackName ?? "", artist, ele.ArtistName, duration, ele.Duration!.Value) > 80);
+            }
         }
 
         // Collect alternate titles and artists from search results
@@ -105,11 +115,6 @@ public class LrcService : ILrcService
 
         if (lyricsDtoMatch == null)
         {
-            //if we fail to find even a single match, just grab first entry if it exists
-            if (searchResults.Count > 0)
-            {
-                return searchResults[0];
-            }
             return null;
         }
 

--- a/ChordKTV/Services/Service/LrcService.cs
+++ b/ChordKTV/Services/Service/LrcService.cs
@@ -76,7 +76,8 @@ public class LrcService : ILrcService
         {
             lyricsDtoMatch = searchResults.FirstOrDefault(ele =>
                 !string.IsNullOrEmpty(ele.PlainLyrics) &&
-                !string.IsNullOrEmpty(ele.SyncedLyrics));
+                !string.IsNullOrEmpty(ele.SyncedLyrics) &&
+                CompareUtils.CompareArtistFuzzyScore(artist, ele.ArtistName) > 70);
         }
 
         // Collect alternate titles and artists from search results

--- a/ChordKTV/Utils/CompareUtils.cs
+++ b/ChordKTV/Utils/CompareUtils.cs
@@ -28,7 +28,7 @@ public static partial class CompareUtils
 
         int artistDifference = 0;
         if (!string.IsNullOrWhiteSpace(artist) && !string.IsNullOrWhiteSpace(candidateArtist))
-        {
+        { //Note that the artist diff pretty high when partial match since it is simple ratio so artist comparison required later.
             artistDifference = 100 - Fuzz.Ratio(artist.ToLowerInvariant(), candidateArtist.ToLowerInvariant());
         }
         return (int)(fuzzyScore - (durationDifference * durationDifferenceWeight) - (artistDifference * artistDifferenceWeight));

--- a/ChordKTV/Utils/CompareUtils.cs
+++ b/ChordKTV/Utils/CompareUtils.cs
@@ -35,7 +35,7 @@ public static partial class CompareUtils
     }
 
     //3 entries, queryArtist being user inputed, candidate artist is the one to test, exactArtist is the initial match in db
-    public static int CompareArtistFuzzyScore(string? queryArtist, string? candidateArtist, string? exactArtist = null, int nullScore = 95, double bonusWeight = 2.12) //dont want null to beat out complete match
+    public static int CompareArtistFuzzyScore(string? queryArtist, string? candidateArtist, string? exactArtist = null, int nullScore = 95, double bonusWeight = 1.6) //dont want null to beat out complete match
     {
         if (string.IsNullOrWhiteSpace(candidateArtist) || (string.IsNullOrWhiteSpace(queryArtist) && string.IsNullOrWhiteSpace(exactArtist))) //need at least two to compare including candidate
         {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->
Search wrong artist was fixed with artist checking in LRC.
Lyric searching was fixed by cleaning the Genius output, assuming quite a few people use eng keyboard searching foreign songs, typically they could search romanized lyrics, resulting in a romanized version of the song showing up in genius, typically by Genius Romanization as the artist (the case here with baka mitai). Modified the gpt prompt a bit and used it for post lyric search cleanup to get us the right candidate artist and redirect back to a research with the full title + artist. 

As side cleanup when testing personal playlists, made Genius search stricter with threshold score
## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #121 
Fixes #120 
## 📷 Screenshots (if applicable)
<!-- Add screenshots or GIFs if visual changes were made. -->
SS for #121 
Added artist checking on LRC for getting the initial results (we only had that verification on the romanized/unromanized twin)
![image](https://github.com/user-attachments/assets/45c3ac80-f242-4bbe-a822-0a71ba21bcf0)

SS for #120 (searched with romanized lyrics: dame da ne dame yo dame na no yo)
![image](https://github.com/user-attachments/assets/5daccc0b-9e3b-484c-b9fb-d8c978bb6566)

## 💬 Additional Comments
<!-- Any additional context or thoughts? -->
Note that our title sorting does a ratio check on the artist, which may come up with low score if partial artist match (for multi-word artist)
