### PR TITLE
Necessary Setup for Deployment

### DIFF
--- a/ChordKTV/Controllers/UserController.cs
+++ b/ChordKTV/Controllers/UserController.cs
@@ -13,7 +13,6 @@ namespace ChordKTV.Controllers;
 
 [ApiController]
 [Route("api")]
-[DevelopmentOnly]
 public class UserController : ControllerBase
 {
     private readonly ILogger<UserController> _logger;

--- a/ChordKTV/Program.cs
+++ b/ChordKTV/Program.cs
@@ -168,9 +168,19 @@ app.UseSwagger();
 app.UseSwaggerUI();
 
 // Comment out HTTPS redirection for development
-app.UseHttpsRedirection();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.MapControllers();
+// Run from static build files on deployment
+if (!app.Environment.IsDevelopment())
+{
+  app.UseDefaultFiles();
+  app.UseStaticFiles();
+  app.MapFallbackToFile("index.html");
+}
 
 PrepDb.Prep(app, app.Environment);
 

--- a/ChordKTV/Program.cs
+++ b/ChordKTV/Program.cs
@@ -177,9 +177,9 @@ app.MapControllers();
 // Run from static build files on deployment
 if (!app.Environment.IsDevelopment())
 {
-  app.UseDefaultFiles();
-  app.UseStaticFiles();
-  app.MapFallbackToFile("index.html");
+    app.UseDefaultFiles();
+    app.UseStaticFiles();
+    app.MapFallbackToFile("index.html");
 }
 
 PrepDb.Prep(app, app.Environment);

--- a/ChordKTV/appsettings.json
+++ b/ChordKTV/appsettings.json
@@ -9,9 +9,6 @@
     "Endpoints": {
       "Http": {
         "Url": "http://0.0.0.0:5259"
-      },
-      "Https": {
-        "Url": "https://0.0.0.0:7027"
       }
     }
   },

--- a/frontend/lyric-sync-app/.env.example
+++ b/frontend/lyric-sync-app/.env.example
@@ -1,1 +1,2 @@
 VITE_GOOGLE_CLIENT_ID=your-google-client-id-here
+VITE_API_BASE_URL=http://localhost:5259

--- a/frontend/lyric-sync-app/README.md
+++ b/frontend/lyric-sync-app/README.md
@@ -5,6 +5,16 @@ To launch frontend:
 
 `npm install`
 
+Create a `.env` file in the frontend/lyric-sync-app directory using `.env.example` as a template:
+
+`cp .env.example .env`
+
+Update the `.env` file with your configuration:
+- `VITE_GOOGLE_CLIENT_ID`: Your Google OAuth client ID for authentication
+- `VITE_API_BASE_URL`: Backend API URL (default: http://localhost:5259 for local development)
+
+Then build and run:
+
 `npm run build`
 
 To pass PR + syntax checks:

--- a/frontend/lyric-sync-app/src/api/apiClient.ts
+++ b/frontend/lyric-sync-app/src/api/apiClient.ts
@@ -1,9 +1,8 @@
 import { SongApi, Configuration, QuizApi, HandwritingApi } from './';
 
-
-const apiConfig = new Configuration({
-  basePath: import.meta.env.VITE_API_URL || 'http://localhost:5259',
-});
+// Use environment variable or fallback to window.location.origin
+const basePath = import.meta.env.VITE_API_BASE_URL || window.location.origin;
+const apiConfig = new Configuration({ basePath });
 
 export const songApi = new SongApi(apiConfig);
 export const quizApi = new QuizApi(apiConfig);

--- a/frontend/lyric-sync-app/src/components/GoogleAuth/GoogleAuth.tsx
+++ b/frontend/lyric-sync-app/src/components/GoogleAuth/GoogleAuth.tsx
@@ -8,7 +8,7 @@ import { AuthApi } from '../../api/apis/AuthApi';
 // Initialize API client
 const authApi = new AuthApi(
   new Configuration({
-    basePath: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5259',
+    basePath: import.meta.env.VITE_API_BASE_URL,
   })
 );
 

--- a/frontend/lyric-sync-app/src/components/GoogleAuth/GoogleAuth.tsx
+++ b/frontend/lyric-sync-app/src/components/GoogleAuth/GoogleAuth.tsx
@@ -8,7 +8,7 @@ import { AuthApi } from '../../api/apis/AuthApi';
 // Initialize API client
 const authApi = new AuthApi(
   new Configuration({
-    basePath: import.meta.env.VITE_API_URL || 'http://localhost:5259',
+    basePath: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5259',
   })
 );
 

--- a/frontend/lyric-sync-app/tsconfig.app.json
+++ b/frontend/lyric-sync-app/tsconfig.app.json
@@ -17,10 +17,11 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src/**/*"],
+  "exclude": ["src/api"]
 }


### PR DESCRIPTION
# 🚀 Pull Request

# **WARNING**: YOU MUST ADD `VITE_API_BASE_URL=http://localhost:5259` TO YOUR .env FILE IN `frontend/lyric-sync-app/`

## 📋 Summary
<!-- Provide a brief explanation of the changes. What problem does this PR fix? -->

Serves from static build files on deployment

Removal of "Https" endpoint in appsettings.json (screws up with getting deployment to work. Https doesn't need to be explicitly added this way on backend. All it needs is an ssl cert + nginx configuration)

BaseURL setup that checks VITE_API_BASE_URL as an env first, then the window url as backup

Relaxes compiler rules to ignore src/api autogenerated files when doing `npm run build`

## 🔍 Related Issues
<!-- Link to related issues, e.g., "Fixes #123" or "Closes #456" -->
Fixes #202 

## 📷 Screenshots (if applicable)
https://chordktv.com
<!-- Add screenshots or GIFs if visual changes were made. -->

## 💬 Additional Comments
Will allow us to get deployed instance on main branch
<!-- Any additional context or thoughts? -->
